### PR TITLE
进一步使用macro简化代码

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-#[macro_use]
 mod declarative;
 
 mod common;
@@ -6,10 +5,9 @@ mod live;
 mod model;
 mod util;
 
-use crate::declarative::Commands;
-use anyhow::{Ok, Result};
+use crate::declarative::{Commands, get_source_url};
+use anyhow::Result;
 use clap::Parser;
-use paste::paste;
 
 /// 获取直播源
 #[derive(Debug, Parser)]
@@ -28,6 +26,5 @@ struct Cli {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    get_resource_impl!(Cli::parse().command; Bili, Douyu, Douyin, Huya, Kuaishou, Cc, Huajiao, Yqs, Mht);
-    Ok(())
+    get_source_url().await
 }


### PR DESCRIPTION
将macro部分放入一个新文件的话，可以进行进一步的声明宏简化代码。此时，command enum以及它的match可以一次性完成，保证了它们二者之间的强一致性。