### PR TITLE
Basic danmu support

### DIFF
--- a/src/declarative.rs
+++ b/src/declarative.rs
@@ -1,4 +1,5 @@
 use crate::{live, Cli, danmu::{self, Danmu}};
+use std::path::PathBuf;
 use anyhow::{Ok, Result};
 use clap::{Parser, Subcommand};
 use paste::paste;
@@ -9,15 +10,13 @@ macro_rules! get_source_url_command {
 
         #[derive(Debug, Subcommand)]
         pub enum Commands {
-            /// 获取B站弹幕
-            Bilidanmu {
-                /// 房间号
-                rid: String
-            },
             $(
                 $name {
                     /// 房间号
                     rid: String,
+                    // 弹幕功能
+                    #[arg(short = 'd')]
+                    danmu: Option<PathBuf>,
                 },
             )*
         }
@@ -26,14 +25,14 @@ macro_rules! get_source_url_command {
         pub async fn get_source_url() -> Result<()> {
             paste! {
                 match Cli::parse().command {
-                    Commands::Bilidanmu { rid } => {
-                        let room_id = live::bili::get_real_room_id(&rid).await.unwrap();
-                        let mut danmu_client = live::bili::BilibiliDanmuClient::new(&room_id);
-                        danmu_client.start(danmu::DanmuRecorder::Terminal).await?;
-                    },
                     $(
-                        Commands::$name { rid } => {
+                        Commands::$name { rid, danmu } => {
                             println!("{}", live::[<$name: lower>]::get(&rid).await?);
+                            // TODO: 目前无视输出参数，直接输出到终端，后期需要保存到参数指定的文件地址
+                            if let Some(_danmu_path) = danmu {
+                                let mut danmu_client = live::[<$name: lower>]::[<$name DanmuClient>]::new(&rid).await;
+                                danmu_client.start(danmu::DanmuRecorder::Terminal).await?;
+                            }
                         }
                     )*
                 }
@@ -49,3 +48,33 @@ macro_rules! get_source_url_command {
 get_source_url_command!(
     Bili, Douyu, Douyin, Huya, Kuaishou, Cc, Huajiao, Yqs, Mht, Now, Afreeca, Panda, Flex, Wink
 );
+
+// 为没有实现弹幕功能的直播平台添加默认空白实现
+#[macro_export]
+macro_rules! default_danmu_client {
+    ($name: ident) => {
+        use paste::paste;
+
+        paste! {
+            use async_trait::async_trait;
+            use crate::danmu::{Danmu, DanmuRecorder};
+
+            pub struct [<$name DanmuClient>] {}
+
+            impl [<$name DanmuClient>] {
+                pub async fn new(_room_id: &str) -> Self {
+                    Self {}
+                }
+            }
+
+            #[async_trait]
+            impl Danmu for [<$name DanmuClient>] {
+                async fn start(&mut self, _recorder: DanmuRecorder) -> Result<()> {
+                    println!("该直播平台暂未实现弹幕功能。");
+                    Ok(())
+                }
+            }
+        }
+
+    }
+}

--- a/src/live/afreeca.rs
+++ b/src/live/afreeca.rs
@@ -3,11 +3,13 @@ use std::collections::HashMap;
 use anyhow::{Ok, Result};
 use regex::Regex;
 
-use crate::{common::CLIENT, model::ShowType, util::parse_url};
+use crate::{common::CLIENT, model::ShowType, util::parse_url, default_danmu_client};
 
 const URL: &str = "https://play.afreecatv.com/";
 const PLAY_URL: &str = "https://live.afreecatv.com/afreeca/player_live_api.php?bjid=";
 const CDN: &str = "https://live-global-cdn-v02.afreecatv.com/live-stmc-32/auth_playlist.m3u8?aid=";
+
+default_danmu_client!(Afreeca);
 
 /// afreecatv直播
 ///

--- a/src/live/bili.rs
+++ b/src/live/bili.rs
@@ -130,14 +130,16 @@ pub async fn get_real_room_id(rid: &str) -> Result<String> {
 }
 
 /// 获取直播弹幕服务
-pub struct BilibiliDanmuClient<'a> {
-    room_id: &'a str,
+pub struct BiliDanmuClient {
+    room_id: String,
     websocket: Option<WebSocketStream<MaybeTlsStream<TcpStream>>>,
 }
 
-impl<'a> BilibiliDanmuClient<'a> {
+impl BiliDanmuClient {
     /// 简单初始化的构造函数
-    pub fn new(room_id: &'a str) -> Self {
+    /// 传入rid
+    pub async fn new(rid: &str) -> Self {
+        let room_id = get_real_room_id(rid).await.unwrap();
         Self {
             room_id,
             websocket: None
@@ -162,7 +164,7 @@ impl<'a> BilibiliDanmuClient<'a> {
 
     /// 初始化websocket
     async fn init_ws(&mut self) {
-        let reg_datas = Self::get_ws_info(self.room_id);
+        let reg_datas = Self::get_ws_info(&self.room_id);
         let (mut ws, _)= tokio_tungstenite::connect_async(WSS_URL).await.unwrap();
         for data in reg_datas {
             Pin::new(&mut ws).start_send(Message::Binary(data)).unwrap();
@@ -304,7 +306,7 @@ impl<'a> BilibiliDanmuClient<'a> {
 }
 
 #[async_trait]
-impl Danmu for BilibiliDanmuClient<'_> {
+impl Danmu for BiliDanmuClient {
     // TODO: 实现其他弹幕记录方式
     async fn start(&mut self, recorder: DanmuRecorder) -> Result<()> {
         if recorder != DanmuRecorder::Terminal {

--- a/src/live/cc.rs
+++ b/src/live/cc.rs
@@ -1,8 +1,10 @@
-use crate::{common::CLIENT, model::ShowType, util::parse_url};
+use crate::{common::CLIENT, model::ShowType, util::parse_url, default_danmu_client};
 use anyhow::{Ok, Result};
 use regex::Regex;
 
 const URL: &str = "https://cc.163.com/";
+
+default_danmu_client!(Cc);
 
 /// 网易CC直播
 ///

--- a/src/live/douyin.rs
+++ b/src/live/douyin.rs
@@ -1,4 +1,4 @@
-use crate::{common::CLIENT, model::ShowType, util::parse_url};
+use crate::{common::CLIENT, model::ShowType, util::parse_url, default_danmu_client};
 
 use anyhow::{Ok, Result};
 use regex::Regex;
@@ -6,6 +6,8 @@ use serde_json::Value;
 use urlencoding::decode;
 
 const URL: &str = "https://live.douyin.com/";
+
+default_danmu_client!(Douyin);
 
 /// 抖音直播
 ///

--- a/src/live/douyu.rs
+++ b/src/live/douyu.rs
@@ -1,6 +1,6 @@
 use std::collections::HashMap;
 
-use crate::{common::CLIENT, model::ShowType};
+use crate::{common::CLIENT, model::ShowType, default_danmu_client};
 
 use crate::util::{do_js, md5, parse_url};
 use anyhow::{Ok, Result};
@@ -14,6 +14,8 @@ const PLAY_URL: &str = "https://www.douyu.com/lapi/live/getH5Play/";
 const CDN_1: &str = "http://akm-tct.douyucdn.cn/live/";
 const CDN_2: &str = "http://ws-tct.douyucdn.cn/live/";
 const DID: &str = "10000000000000000000000000001501";
+
+default_danmu_client!(Douyu);
 
 /// 斗鱼直播
 ///

--- a/src/live/flex.rs
+++ b/src/live/flex.rs
@@ -1,8 +1,10 @@
 use anyhow::{Ok, Result};
 
-use crate::{common::CLIENT, model::ShowType, util::parse_url};
+use crate::{common::CLIENT, model::ShowType, util::parse_url, default_danmu_client};
 
 const URL: &str = "https://api.flextv.co.kr/api/channels/rid/stream?option=all";
+
+default_danmu_client!(Flex);
 
 /// flextv
 ///

--- a/src/live/huajiao.rs
+++ b/src/live/huajiao.rs
@@ -1,9 +1,11 @@
 use anyhow::{Ok, Result};
 use regex::Regex;
 
-use crate::{common::CLIENT, model::ShowType, util::parse_url};
+use crate::{common::CLIENT, model::ShowType, util::parse_url, default_danmu_client};
 
 const URL: &str = "https://www.huajiao.com/l/";
+
+default_danmu_client!(Huajiao);
 
 /// 花椒直播
 ///

--- a/src/live/huya.rs
+++ b/src/live/huya.rs
@@ -1,9 +1,11 @@
 use anyhow::{Ok, Result};
 use regex::Regex;
 
-use crate::{common::CLIENT, model::ShowType, util::parse_url};
+use crate::{common::CLIENT, model::ShowType, util::parse_url, default_danmu_client};
 
 const URL: &str = "https://www.huya.com/";
+
+default_danmu_client!(Huya);
 
 /// 虎牙直播
 ///

--- a/src/live/kuaishou.rs
+++ b/src/live/kuaishou.rs
@@ -5,9 +5,12 @@ use crate::{
     common::{CLIENT, USER_AGENT},
     model::ShowType,
     util::parse_url,
+    default_danmu_client
 };
 
 const URL: &str = "https://live.kuaishou.com/u/";
+
+default_danmu_client!(Kuaishou);
 
 /// 快手直播
 ///

--- a/src/live/mht.rs
+++ b/src/live/mht.rs
@@ -1,9 +1,11 @@
-use crate::{common::CLIENT, model::ShowType, util::parse_url};
+use crate::{common::CLIENT, model::ShowType, util::parse_url, default_danmu_client};
 
 use anyhow::{Ok, Result};
 use serde_json::Value;
 
 const URL: &str = "https://www.2cq.com/proxy/room/room/info";
+
+default_danmu_client!(Mht);
 
 /// 棉花糖直播
 ///

--- a/src/live/now.rs
+++ b/src/live/now.rs
@@ -1,8 +1,10 @@
 use anyhow::{Ok, Result};
 
-use crate::{model::ShowType, common::CLIENT, util::parse_url};
+use crate::{model::ShowType, common::CLIENT, util::parse_url, default_danmu_client};
 
 const URL: &str = "https://now.qq.com/cgi-bin/now/web/room/get_live_room_url?platform=8&room_id=";
+
+default_danmu_client!(Now);
 
 /// NOW直播
 ///

--- a/src/live/panda.rs
+++ b/src/live/panda.rs
@@ -4,7 +4,9 @@ use anyhow::{Ok, Result};
 
 const URL: &str = "https://api.pandalive.co.kr/v1/live/play/";
 
-use crate::{common::CLIENT, model::ShowType, util::parse_url};
+use crate::{common::CLIENT, model::ShowType, util::parse_url, default_danmu_client};
+
+default_danmu_client!(Panda);
 
 /// pandalive
 ///

--- a/src/live/wink.rs
+++ b/src/live/wink.rs
@@ -4,7 +4,9 @@ use anyhow::{Ok, Result};
 
 const URL: &str = "https://api.winktv.co.kr/v1/live/play";
 
-use crate::{common::CLIENT, model::ShowType, util::parse_url};
+use crate::{common::CLIENT, model::ShowType, util::parse_url, default_danmu_client};
+
+default_danmu_client!(Wink);
 
 /// winktv
 ///

--- a/src/live/yqs.rs
+++ b/src/live/yqs.rs
@@ -1,9 +1,11 @@
-use crate::{common::CLIENT, model::ShowType, util::parse_url};
+use crate::{common::CLIENT, model::ShowType, util::parse_url, default_danmu_client};
 
 use anyhow::{Ok, Result};
 use std::collections::HashMap;
 
 const URL: &str = "https://www.173.com/room/getVieoUrl";
+
+default_danmu_client!(Yqs);
 
 /// 艺气山直播
 ///


### PR DESCRIPTION
实现了类似于`seam [平台] [rid] [-d] [弹幕文件保存地址（目前会被无视，然后直接输出到终端）]`的命令。

目前测了了bili的弹幕功能正常，测试命令为"cargo run bili 7777 -d abc"，该直播间属于弹幕量较大直播时长较长的直播间，适合作为测试直播间。