### PR TITLE
在bili弹幕decode_msg函数里使用serde_json语法糖，相关讨论见pr#28

### DIFF
--- a/src/live/bili.rs
+++ b/src/live/bili.rs
@@ -297,45 +297,13 @@ impl BiliDanmuClient {
 
                 if msg.get("msg_type").unwrap() == "danmu" {
                     // TODO: 可能panic，需要处理第二种情况: j.get("data").unwrap().get("uname").unwrap().as_str().unwrap().to_string();
-                    let name = j
-                        .get("info")
-                        .unwrap()
-                        .get(2)
-                        .unwrap()
-                        .get(1)
-                        .unwrap()
-                        .as_str()
-                        .unwrap()
-                        .trim()
-                        .to_string();
-                    let content = j
-                        .get("info")
-                        .unwrap()
-                        .get(1)
-                        .unwrap()
-                        .as_str()
-                        .unwrap()
-                        .trim()
-                        .to_string();
+                    let name = j["info"][2][1].as_str().unwrap().trim().to_string();
+                    let content = j["info"][1].as_str().unwrap().trim().to_string();
                     msg.insert("name".to_owned(), name);
                     msg.insert("content".to_owned(), content);
                 } else if msg.get("msg_type").unwrap() == "interactive_danmaku" {
-                    let name = j
-                        .get("data")
-                        .unwrap()
-                        .get("uname")
-                        .unwrap()
-                        .as_str()
-                        .unwrap()
-                        .to_string();
-                    let content = j
-                        .get("data")
-                        .unwrap()
-                        .get("msg")
-                        .unwrap()
-                        .as_str()
-                        .unwrap()
-                        .to_string();
+                    let name = j["data"]["uname"].as_str().unwrap().to_string();
+                    let content = j["data"]["msg"].as_str().unwrap().to_string();
                     msg.insert("name".to_owned(), name);
                     msg.insert("content".to_owned(), content);
                 } else {


### PR DESCRIPTION
将bili弹幕服务解码部分的serde_json使用语法糖重写，相关讨论见pr[#28](https://github.com/Borber/seam/pull/28)。