### PR TITLE
修复弹幕服务的一些问题

### DIFF
--- a/src/declarative.rs
+++ b/src/declarative.rs
@@ -33,7 +33,7 @@ macro_rules! get_source_url_command {
                             println!("{}", live::[<$name: lower>]::get(&rid).await?);
                             // TODO: 目前无视输出参数，直接输出到终端，后期需要保存到参数指定的文件地址
                             if let Some(_danmu_path) = danmu {
-                                let mut danmu_client = live::[<$name: lower>]::[<$name DanmuClient>]::new(&rid).await;
+                                let mut danmu_client = live::[<$name: lower>]::[<$name DanmuClient>]::try_new(&rid).await?;
                                 danmu_client.start(danmu::DanmuRecorder::Terminal).await?;
                             }
                         }
@@ -65,8 +65,8 @@ macro_rules! default_danmu_client {
             pub struct [<$name DanmuClient>] {}
 
             impl [<$name DanmuClient>] {
-                pub async fn new(_room_id: &str) -> Self {
-                    Self {}
+                pub async fn try_new(_room_id: &str) -> Result<Self> {
+                    Ok(Self {})
                 }
             }
 

--- a/src/live/bili.rs
+++ b/src/live/bili.rs
@@ -128,9 +128,12 @@ pub struct BiliDanmuClient {
 }
 
 impl BiliDanmuClient {
-    pub async fn new(rid: &str) -> Self {
-        let (_, room_id, _) = get_real_room_info(rid).await.unwrap();
-        Self { room_id }
+    pub async fn try_new(rid: &str) -> Result<Self> {
+        if let Some((_, room_id, _)) = get_real_room_info(rid).await {
+            Ok(Self { room_id })
+        } else {
+            Err(anyhow!("直播间不存在"))
+        }
     }
 
     fn init_msg_generator(room_id: &str) -> Vec<Vec<u8>> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,5 +25,6 @@ struct Cli {
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    get_source_url().await
+    get_source_url().await.unwrap();
+    Ok(())
 }


### PR DESCRIPTION
# commit 1：修复了直播结束后弹幕服务没有关闭的问题

- `websocket_danmu_work_flow`要求一个额外的入参，来检查直播间是否关闭，若是关闭，则返回函数。
- 心跳机制将更符合逻辑，若是遇到网络波动，传输数据流失败则在短时间后再次尝试，而非提前返回使得弹幕服务失效。此分支函数只会在websocket被server关闭后返回。
- 弹幕获取功能将不需要返回参数。websocket被server关闭后将返回。

# commit 2：修复了直播间不存在时panic位置不合理的问题

## 问题：
原来的代码中，在构建弹幕服务结构体时会request直播间信息，当直播间不存在时返回NONE，此时unwrap会在new时直接panic。在CLI程序中，这种做法是可以接受的，但是在GUI程序中，当输入错误的直播间id，企图开启弹幕时会导致整个程序的panic。

## 解决方案：
使用`try_new`代替`new`，将None转化为Err层层上传，在CLI的main函数处再panic，此时core部分不会panic只会上传至顶层进行处理。在GUI程序中，可以使用alert来提示而不是panic，在CLI中可以在顶层直接panic。
