### PR TITLE
fix：完整实现默认弹幕文件名

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -44,6 +44,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi 0.1.19",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -160,6 +171,17 @@ checksum = "3538270d33cc669650c4b093848450d380def10c331d38c768e34cac80576e6e"
 dependencies = [
  "termcolor",
  "unicode-width",
+]
+
+[[package]]
+name = "colored"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3616f750b84d8f0de8a58bda93e08e2a81ad3f523089b05f1dffecab48c6cbd"
+dependencies = [
+ "atty",
+ "lazy_static",
+ "winapi",
 ]
 
 [[package]]
@@ -415,6 +437,15 @@ checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
 
 [[package]]
 name = "hermit-abi"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "hermit-abi"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee512640fe35acbfb4bb779db6f0d80704c2cacfa2e39b601ef3e3f47d1ae4c7"
@@ -574,7 +605,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dfb6c8100ccc63462345b67d1bbc3679177c75ee4bf59bf29c8b1d110b8189"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "io-lifetimes",
  "rustix",
  "windows-sys",
@@ -726,7 +757,7 @@ version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fac9e2da13b5eb447a6ce3d392f23a29d8694bff781bf03a16cd9ac8697593b"
 dependencies = [
- "hermit-abi",
+ "hermit-abi 0.2.6",
  "libc",
 ]
 
@@ -1039,6 +1070,7 @@ dependencies = [
  "async-trait",
  "chrono",
  "clap",
+ "colored",
  "futures-sink",
  "futures-util",
  "hex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,4 @@ tokio-tungstenite = { version = "0.18", features = ["native-tls"] }
 futures-sink = "0.3"
 futures-util = { version = "0.3", default-features = false, features = ["sink", "std"] }
 miniz_oxide = "0.6.2"
+colored = "2.0.0"

--- a/src/danmu.rs
+++ b/src/danmu.rs
@@ -85,7 +85,9 @@ pub struct Csv {
 
 impl DanmuRecorder for Csv {
     fn try_new(path: Option<PathBuf>) -> Result<Self> {
-        let path = path.ok_or_else(|| anyhow::anyhow!("初始化CSV弹幕记录器时未指定文件地址"))?;
+        let file_stem =
+            path.ok_or_else(|| anyhow::anyhow!("初始化CSV弹幕记录器时未指定文件地址"))?;
+        let path = file_stem.with_extension("csv");
         Ok(Self { path })
     }
 

--- a/src/danmu.rs
+++ b/src/danmu.rs
@@ -9,9 +9,12 @@
 use std::future::Future;
 use std::path::PathBuf;
 use std::pin::Pin;
+use std::fs::{File, OpenOptions};
+use std::io::prelude::*;
 
 use anyhow::Result;
 use async_trait::async_trait;
+use colored::Colorize;
 use futures_sink::Sink;
 use futures_util::stream::{SplitSink, SplitStream};
 use futures_util::{SinkExt, StreamExt};
@@ -29,18 +32,92 @@ pub trait Danmu {
     /// # Errors
     ///
     /// 发生不可继续运行的错误的情况下，返回错误。
-    async fn start(&mut self, recorder: DanmuRecorder) -> Result<()>;
+    async fn start(&mut self, recorder: Vec<&dyn DanmuRecorder>) -> Result<()>;
 }
 
-/// 弹幕记录方式: 文件, 终端, 文件+终端, 不记录。
-// TODO: 未来可能会添加其他记录方式，比如sqlite，xml等。
-// TODO: 为了方便，目前只支持终端输出，后期需要添加文件输出。所以暂时allow dead_code。
-#[allow(dead_code)]
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum DanmuRecorder {
-    File(PathBuf),
-    Terminal,
-    None,
+/// 标准化弹幕记录trait。
+/// 
+/// 本trait提供了标准化的弹幕记录方式。
+/// 
+/// - try_new: 尝试使用给定的地址初始化弹幕记录器，None地址可以被终端记录器接受，其他必须有文件地址。
+/// - path: 获取弹幕记录的地址，输出到终端为None。
+/// - init: 初始化弹幕记录器，如创建文件，创建表头，创建文件格式信息（如BOM头等）。
+/// - formatter: 格式化弹幕，将弹幕转换为字符串。
+/// - record: 记录弹幕（自动调用自带的formatter函数，所以入参为`&DanmuBody`）。
+pub trait DanmuRecorder: Send + Sync {
+    fn try_new(path: Option<PathBuf>) -> Result<Self> where Self: Sized;
+    fn path(&self) -> Option<&PathBuf>;
+
+    fn init(&self) -> Result<()> {
+        let path = self.path().ok_or(anyhow::anyhow!("no supported path pamameter"))?;
+        File::create(path)?;
+        Ok(())
+    }
+
+    fn formatter(&self, danmu: &DanmuBody) -> String {
+        format!("{}{}    {}", danmu.user.yellow(), ":".yellow(), danmu.content.green().bold())
+    }
+
+    fn record(&self, danmu: &DanmuBody) -> Result<()> {
+        let path = self.path().ok_or(anyhow::anyhow!("no supported path pamameter"))?;
+        let mut file = OpenOptions::new().append(true).open(path)?;
+        file.write_all(self.formatter(danmu).as_bytes())?;
+        file.write_all(b"\n")?;
+        Ok(())
+    }
+}
+
+/// CSV弹幕记录器。
+pub struct Csv {
+    path: PathBuf,
+}
+
+impl DanmuRecorder for Csv {
+    fn try_new(path: Option<PathBuf>) -> Result<Self> {
+        let path = path.ok_or(anyhow::anyhow!("初始化CSV弹幕记录器时未指定文件地址"))?;
+        Ok(Self { path })
+    }
+
+    fn path(&self) -> Option<&PathBuf> {
+        Some(&self.path)
+    }
+
+    /// 初始化csv文件
+    /// - 添加BOM头
+    /// - 添加表头
+    fn init(&self) -> Result<()> {
+        let mut file = File::create(&self.path)?;
+        let mut init_info: Vec<u8> = vec![0xEF, 0xBB, 0xBF];
+        init_info.extend(b"user, content\n");
+        file.write_all(&init_info)?;
+        Ok(())
+    }
+
+    fn formatter(&self, danmu: &DanmuBody) -> String {
+        format!("{}, {}", danmu.user, danmu.content)
+    }
+}
+
+pub struct Terminal;
+
+impl DanmuRecorder for Terminal {
+    fn try_new(_path: Option<PathBuf>) -> Result<Self> {
+        Ok(Self)
+    }
+
+    fn path(&self) -> Option<&PathBuf> {
+        None
+    }
+
+    fn init(&self) -> Result<()> {
+        println!("即将在终端输出弹幕：");
+        Ok(())
+    }
+
+    fn record(&self, danmu: &DanmuBody) -> Result<()> {
+        println!("{}", &self.formatter(danmu));
+        Ok(())
+    }
 }
 
 /// 标准弹幕格式
@@ -92,8 +169,7 @@ impl DanmuBody {
 pub async fn websocket_danmu_work_flow<B>(
     room_id: &str,
     url: &str,
-    recorder: DanmuRecorder,
-    recorder_checker: fn(&DanmuRecorder) -> Result<()>,
+    recorder: Vec<&dyn DanmuRecorder>,
     init_msg_generator: fn(&str) -> Vec<Vec<u8>>,
     is_closed_room: impl Fn() -> B,
     heart_beat_msg_generator: fn() -> Vec<u8>,
@@ -103,9 +179,6 @@ pub async fn websocket_danmu_work_flow<B>(
 where
     B: Future<Output = Option<bool>>,
 {
-    // 检查recorder是否支持
-    recorder_checker(&recorder)?;
-
     // 初始化websocket连接
     let reg_datas = init_msg_generator(room_id);
     let (mut ws, _) = tokio_tungstenite::connect_async(url).await?;
@@ -121,7 +194,7 @@ where
     tokio::select! {
         _ = closed_room_checker(is_closed_room) => { }
         _ = heart_beat(&mut write, heart_beat_msg_generator, heart_beat_interval) => { println!("websocket已关闭"); }
-        _ = fetch_danmu(&mut read, decode_and_record_danmu, &recorder) => { println!("websocket已关闭"); }
+        e = fetch_danmu(&mut read, decode_and_record_danmu, recorder) => { e?; }
     }
 
     Ok(())
@@ -175,22 +248,28 @@ async fn heart_beat(
 async fn fetch_danmu(
     ws_read: &mut SplitStream<WebSocketStream<MaybeTlsStream<TcpStream>>>,
     decode_and_record_danmu: fn(&[u8]) -> Result<Vec<DanmuBody>>,
-    recorder: &DanmuRecorder,
-) {
+    recorder: Vec<&dyn DanmuRecorder>,
+) -> Result<()> {
+    // 初始化recorder
+    for r in recorder.iter() {
+        r.init()?;
+    }
+
     let ws_to_stdout = {
         ws_read.for_each(|message| async {
             let data = message.unwrap().into_data();
             let msgs = decode_and_record_danmu(&data).unwrap();
-            match recorder {
-                DanmuRecorder::File(_) => {}
-                DanmuRecorder::Terminal => {
-                    msgs.iter().for_each(|DanmuBody { user, content }| {
-                        println!("user: {user}, content: {content}");
-                    });
+            for msg in msgs.iter() {
+                for r in recorder.iter() {
+                    if let Err(e) = r.record(msg) {
+                        println!("记录弹幕失败: {}", e);
+                        println!("弹幕内容: {:?}", msg.content);
+                    }
                 }
-                DanmuRecorder::None => {}
-            };
+            }
         })
     };
+
     ws_to_stdout.await;
+    Ok(())
 }

--- a/src/declarative.rs
+++ b/src/declarative.rs
@@ -1,6 +1,8 @@
 use crate::{
     danmu::{Csv, Danmu, DanmuRecorder, Terminal},
-    live, Cli,
+    live,
+    util::get_datetime,
+    Cli,
 };
 use anyhow::{anyhow, Ok, Result};
 use clap::{Parser, Subcommand};
@@ -39,7 +41,9 @@ macro_rules! get_source_url_command {
                             if config_danmu {
                                 let mut danmu_client = live::[<$name: lower>]::[<$name DanmuClient>]::try_new(&rid).await?;
                                 let cwd = std::env::current_exe()?; // 对于MACOS，CWD可执行文件目录，所以需要使用current_exe
-                                let file_name = "danmu.csv"; // 临时使用，后续时间戳实现后会改为参数
+                                let room_info = live::[<$name: lower>]::get(&rid).await?;
+                                let room_title = room_info.get_room_title().or(Some("未知直播标题")).unwrap();
+                                let file_name = format!("{}-{}-{}", rid, get_datetime(), room_title);
                                 let path = PathBuf::from(cwd.parent().ok_or(anyhow!("错误的弹幕记录地址。"))?).join(file_name);
                                 danmu_client.start(vec![&Csv::try_new(Some(path))?]).await?;
                             } else if danmu {

--- a/src/declarative.rs
+++ b/src/declarative.rs
@@ -1,5 +1,5 @@
 use crate::{
-    danmu::{Danmu, DanmuRecorder, Terminal, Csv},
+    danmu::{Csv, Danmu, DanmuRecorder, Terminal},
     live, Cli,
 };
 use anyhow::{anyhow, Ok, Result};
@@ -35,7 +35,7 @@ macro_rules! get_source_url_command {
                         Commands::$name { rid, danmu, config_danmu } => {
                             // 参数D为最高优先级
                             // 参数d为次高优先级
-                            // 两个参数都没有时，直接输出直播源信息 
+                            // 两个参数都没有时，直接输出直播源信息
                             if config_danmu {
                                 let mut danmu_client = live::[<$name: lower>]::[<$name DanmuClient>]::try_new(&rid).await?;
                                 let cwd = std::env::current_exe()?; // 对于MACOS，CWD可执行文件目录，所以需要使用current_exe
@@ -61,7 +61,8 @@ macro_rules! get_source_url_command {
 // 展开宏命令
 // 添加新的直播平台可以在括号末尾添加，并在live文件夹里添加对应的文件
 get_source_url_command!(
-    Bili, Douyu, Douyin, Huya, Kuaishou, Cc, Huajiao, Kk, Qf, Yqs, Mht, Now, Afreeca, Panda, Flex, Wink
+    Bili, Douyu, Douyin, Huya, Kuaishou, Cc, Huajiao, Kk, Qf, Yqs, Mht, Now, Afreeca, Panda, Flex,
+    Wink
 );
 
 // 为没有实现弹幕功能的直播平台添加默认空白实现

--- a/src/live/bili.rs
+++ b/src/live/bili.rs
@@ -245,14 +245,7 @@ async fn is_closed_room(rid: &str) -> Option<bool> {
 
 #[async_trait]
 impl Danmu for BiliDanmuClient {
-    async fn start(&mut self, recorder: DanmuRecorder) -> Result<()> {
-        let recorder_checker = |recorder: &DanmuRecorder| {
-            if recorder != &DanmuRecorder::Terminal {
-                return Err(anyhow!("Bilibili弹幕服务目前仅支持终端输出。"));
-            }
-            Ok(())
-        };
-
+    async fn start(&mut self, recorder: Vec<&dyn DanmuRecorder>) -> Result<()> {
         let heart_beat_msg_generator = || HEART_BEAT.as_bytes().to_vec();
         let heart_beat_interval = HEART_BEAT_INTERVAL;
 
@@ -263,7 +256,6 @@ impl Danmu for BiliDanmuClient {
             &self.room_id,
             WSS_URL,
             recorder,
-            recorder_checker,
             Self::init_msg_generator,
             is_closed_room_closure,
             heart_beat_msg_generator,

--- a/src/model.rs
+++ b/src/model.rs
@@ -12,6 +12,15 @@ pub enum ShowType {
     Error(String),
 }
 
+impl ShowType {
+    pub fn get_room_title(&self) -> Option<&str> {
+        match self {
+            ShowType::On(detail) => Some(detail.title.as_str()),
+            _ => None,
+        }
+    }
+}
+
 impl Display for ShowType {
     fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
         match self {

--- a/src/util.rs
+++ b/src/util.rs
@@ -45,3 +45,10 @@ pub fn parse_url(url: String) -> Node {
         url: url.to_owned(),
     }
 }
+
+/// 获取当前时间
+/// 格式：20230121-000000-000 (年月日-时分秒-毫秒)
+#[inline]
+pub fn get_datetime() -> String {
+    chrono::Local::now().format("%Y%m%d-%H%M%S-%3f").to_string()
+}


### PR DESCRIPTION
# 原代码
- 原代码默认弹幕保存功能仅作为测试使用，无视情况无视保存格式的实现，默认弹幕文件名为"danmu.csv"

# 新代码
- 新代码将其修改为"[RID]-[YYMMDD]-[HHMMSS]-[SSS]-[TITLE]"，并在传入recorder后再根据其type指定后缀名