### PR TITLE
CLI参数匹配的异步插件化；基础的下载和监控功能

### DIFF
--- a/src/declarative.rs
+++ b/src/declarative.rs
@@ -1,10 +1,8 @@
 use crate::{
     danmu::{Csv, Danmu, DanmuRecorder, Terminal},
-    live,
+    live, model, recorder,
     util::get_datetime,
     Cli,
-    model,
-    recorder,
 };
 
 use std::path::PathBuf;
@@ -67,12 +65,12 @@ macro_rules! get_source_url_command {
 
                             // 收集不同参数功能的异步线程handler
                             let mut thread_handlers = vec![];
-                            
+
                             // 处理参数-d，直接输出弹幕。
                             // 由于该函数为cli层，所以出错可以直接panic。
                             if danmu {
                                 let rid_clone = rid.clone();
-                                let h = tokio::spawn(async move { 
+                                let h = tokio::spawn(async move {
                                     let mut danmu_client = live::[<$name: lower>]::[<$name DanmuClient>]::try_new(&rid_clone).await.unwrap();
                                     danmu_client.start(vec![&Terminal::try_new(None).unwrap()]).await.unwrap();
                                 });

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ mod common;
 mod danmu;
 mod live;
 mod model;
+mod recorder;
 mod util;
 
 use crate::declarative::{get_source_url, Commands};

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,6 +1,8 @@
 use std::fmt::{Display, Formatter, Result as FmtResult};
+use std::ops::Deref;
 
 use serde::{Serialize, Serializer};
+use anyhow::{Result, anyhow};
 
 #[derive(Serialize, Debug)]
 pub enum ShowType {
@@ -17,6 +19,13 @@ impl ShowType {
         match self {
             ShowType::On(detail) => Some(detail.title.as_str()),
             _ => None,
+        }
+    }
+
+    pub fn is_on(&self) -> bool {
+        match self {
+            ShowType::On(_) => true,
+            _ => false,
         }
     }
 
@@ -50,12 +59,29 @@ impl Detail {
     }
 }
 
+impl Deref for Detail {
+    type Target = Vec<Node>;
+
+    fn deref(&self) -> &Self::Target {
+        &self.nodes
+    }
+}
+
 #[derive(Serialize, Debug)]
 pub struct Node {
     // 直播源格式
     pub format: Format,
     // 直播源地址, 默认均为最高清晰度, 故而无需额外标注清晰度
     pub url: String,
+}
+
+impl Node {
+    pub fn is_m3u8(&self) -> Result<String> {
+        match self.format {
+            Format::M3U => Ok(self.url.clone()),
+            _ => Err(anyhow!("不是m3u8格式")),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/src/model.rs
+++ b/src/model.rs
@@ -19,6 +19,13 @@ impl ShowType {
             _ => None,
         }
     }
+
+    pub fn is_bad_rid(&self) -> bool {
+        match self {
+            ShowType::Error(_) => true,
+            _ => false,
+        }
+    }
 }
 
 impl Display for ShowType {

--- a/src/model.rs
+++ b/src/model.rs
@@ -23,17 +23,11 @@ impl ShowType {
     }
 
     pub fn is_on(&self) -> bool {
-        match self {
-            ShowType::On(_) => true,
-            _ => false,
-        }
+        matches!(self, ShowType::On(_))
     }
 
     pub fn is_bad_rid(&self) -> bool {
-        match self {
-            ShowType::Error(_) => true,
-            _ => false,
-        }
+        matches!(self, ShowType::Error(_))
     }
 }
 
@@ -104,5 +98,36 @@ impl Serialize for Format {
             Format::Other(s) => s.as_str(),
         };
         serializer.serialize_str(str)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_is_on() {
+        let detail = Detail::new("title".to_string(), vec![]);
+        let show_type = ShowType::On(detail);
+        assert!(show_type.is_on());
+
+        let show_type = ShowType::Off;
+        assert!(!show_type.is_on());
+
+        let show_type = ShowType::Error("error".to_string());
+        assert!(!show_type.is_on());
+    }
+
+    #[test]
+    fn test_is_bad_rid() {
+        let detail = Detail::new("title".to_string(), vec![]);
+        let show_type = ShowType::On(detail);
+        assert!(!show_type.is_bad_rid());
+
+        let show_type = ShowType::Off;
+        assert!(!show_type.is_bad_rid());
+
+        let show_type = ShowType::Error("error".to_string());
+        assert!(show_type.is_bad_rid());
     }
 }

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,8 +1,8 @@
 use std::fmt::{Display, Formatter, Result as FmtResult};
 use std::ops::Deref;
 
+use anyhow::{anyhow, Result};
 use serde::{Serialize, Serializer};
-use anyhow::{Result, anyhow};
 
 #[derive(Serialize, Debug)]
 pub enum ShowType {

--- a/src/recorder.rs
+++ b/src/recorder.rs
@@ -4,7 +4,7 @@ pub async fn record(url: &str, output: &str) {
     let exe = std::env::current_exe().unwrap();
     let cwd = exe.parent().unwrap();
     Command::new("ffmpeg")
-        .args(&[
+        .args([
             "-hide_banner",
             "-loglevel",
             "error",

--- a/src/recorder.rs
+++ b/src/recorder.rs
@@ -1,0 +1,23 @@
+use tokio::process::Command;
+
+pub async fn record(url: &str, output: &str) {
+    let exe = std::env::current_exe().unwrap();
+    let cwd = exe.parent().unwrap();
+    Command::new("ffmpeg")
+        .args(&[
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-i",
+            url,
+            "-c",
+            "copy",
+            output,
+        ])
+        .current_dir(cwd)
+        .spawn()
+        .unwrap()
+        .wait()
+        .await
+        .unwrap();
+} 

--- a/src/recorder.rs
+++ b/src/recorder.rs
@@ -20,4 +20,4 @@ pub async fn record(url: &str, output: &str) {
         .wait()
         .await
         .unwrap();
-} 
+}


### PR DESCRIPTION
# 参数匹配的异步插件化

将CLI每个参数的功能都写成spawn一个新的异步线程，保证了每个功能的解耦。此后，每增加一个CLI输入参数，只需要在工作栈上压入一个新功能线程即可。

# 基础的下载和监控功能

## 基础的下载功能 【-r】
使用`ffmpeg -i [url] -c copy [title.mp4]`命令进行下载。需要对应的ffmpeg进行辅助下载。

## 基础的监控功能 【-R】
添加监控功能，3-9分钟随机查询一次是否开播，开播即可下载。

# warning
1. 目前仅b站直播下载通过测试。
2. 自动监控下载功能仍未完善，自动监控目前只能录播，但还无法激活弹幕下载功能。