### PR TITLE
修复 bili 带 cookie 时不能获取原画的问题  (#277) 

### DIFF
--- a/crates/core/src/live/bili.rs
+++ b/crates/core/src/live/bili.rs
@@ -132,10 +132,13 @@ impl Live for Client {
 }
 
 /// 通过真实房间号获取直播源信息
-pub async fn get_bili_stream_info(rid: &str, qn: u64) -> Result<serde_json::Value> {
+/// 不带 cookie 只给 480P, 带 cookie 才给原画画质
+pub async fn get_bili_stream_info(rid: &str, qn: u64, headers: Option<HashMap<String, String>>) -> Result<serde_json::Value> {
+    let mut headers = hash2header(headers);
+    headers.append("User-Agent", HeaderValue::from_static(USER_AGENT));
     Ok(CLIENT
         .get(PLAY_URL)
-        .header("User-Agent", USER_AGENT)
+        .headers(headers)
         .query(&[
             ("room_id", rid),
             ("protocol", "0,1"),

--- a/crates/core/src/live/bili.rs
+++ b/crates/core/src/live/bili.rs
@@ -42,7 +42,7 @@ impl Live for Client {
             _ => return Err(SeamError::None),
         };
 
-        let mut stream_info = get_bili_stream_info(&rid, 10000).await?;
+        let mut stream_info = get_bili_stream_info(&rid, 10000, headers).await?;
 
         let max = stream_info
             .as_array()
@@ -61,7 +61,7 @@ impl Live for Client {
             .ok_or(SeamError::NeedFix("max"))?;
 
         if max != 10000 {
-            stream_info = get_bili_stream_info(&rid, max).await?;
+            stream_info = get_bili_stream_info(&rid, max, headers).await?;
         }
 
         let mut urls = vec![];


### PR DESCRIPTION
在 #277 中有报告, B 站 10 月更新后, 不带 cookie 只能获取 480P ("高清") 画质, 带上 cookie 才能获取到更高画质
但 seam 即使配置了B站 cookie, 也不会用于获取B站流地址, 导致用户只能获得 480P 画质的流
这个 PR 尝试修复这个问题